### PR TITLE
Avoid to run OCR for digital PDF files Issue 4

### DIFF
--- a/common/src/main/scala/datasources/PdfPartitionReadedBase.scala
+++ b/common/src/main/scala/datasources/PdfPartitionReadedBase.scala
@@ -30,6 +30,7 @@ abstract class PdfPartitionReadedBase(inputPartition: FilePartition,
 
   override def get(): InternalRow = {
     val resolution = options.getOrElse("resolution", DefaultOptions.RESOLUTION).toInt
+    val forceOCR = options.getOrElse("forceOCR", "false").toBoolean
 
     val text = if (readDataSchema.fieldNames.contains("text")) {
       getSearchableText
@@ -51,7 +52,11 @@ abstract class PdfPartitionReadedBase(inputPartition: FilePartition,
 
     // Run OCR on the image
     val ocrDocument = if (readDataSchema.fieldNames.contains("document")) {
-      tesseract.imageToDocument(image, PIL.WORD, 0, filename)
+      if (forceOCR || text.isEmpty) {
+        tesseract.imageToDocument(image, PIL.WORD, 0, filename)
+      } else {
+        Document(filename, "", "", Array[Box]())
+      }
     } else
       Document(filename, "", "", Array[Box]())
 

--- a/common/src/main/scala/datasources/PdfPartitionReaderPDFBox.scala
+++ b/common/src/main/scala/datasources/PdfPartitionReaderPDFBox.scala
@@ -1,0 +1,133 @@
+package com.stabrise.sparkpdf
+package datasources
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.rendering.{PDFRenderer, ImageType => PDFBoxImageType}
+import org.apache.pdfbox.text.PDFTextStripper
+import org.apache.spark.sql.execution.datasources.FilePartition
+import org.apache.spark.sql.types.StructType
+
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+
+// TODO: Need to refactor it for reduce to use state variables and make it more transparent
+class PdfPartitionReaderPDFBox(inputPartition: FilePartition,
+                               readDataSchema: StructType,
+                               options: Map[String,String])
+  extends PdfPartitionReadedBase(inputPartition, readDataSchema, options) {
+
+  private var currenFile = 0
+  private val outputImageType = options.getOrElse("outputImageType", DefaultOptions.OUTPUT_IMAGE_TYPE)
+  private var pageNum: Int = inputPartition.files(currenFile).start.toInt
+  private var document: PDDocument = _
+  private var stripper: PDFTextStripper = _
+  private var pdfRenderer: PDFRenderer = _
+
+  def next():Boolean = {
+    if (currenFile < inputPartition.files.length) {
+      val file = inputPartition.files(currenFile)
+      if (pageNum == file.start.toInt) {
+        filename = file.filePath.toString()
+        val hdfsPath = PdfPartitionedFileUtil.getHdfsPath(file)
+        val fs = hdfsPath.getFileSystem(new Configuration())
+        val status = fs.getFileStatus(hdfsPath)
+        document = PDDocument.load(fs.open(status.getPath))
+        stripper = new PDFTextStripper()
+        pdfRenderer = new PDFRenderer(document)
+      }
+      pageNumCur = pageNum
+      if (pageNum < file.length + file.start - 1 && pageNum < document.getNumberOfPages) {
+        pageNum += 1
+      } else {
+        currenFile += 1
+        if (currenFile < inputPartition.files.length) {
+          pageNum = inputPartition.files(currenFile).start.toInt
+        }
+      }
+      true
+    } else {
+      false
+    }
+  }
+
+  override def getSearchableText(): String = {
+    stripper.setStartPage (pageNumCur + 1)
+    stripper.setEndPage (pageNumCur + 1)
+    stripper.getText (document)
+  }
+
+  override def renderImage(resolution: Int): Array[Byte] = {
+    val imageType = options.getOrElse("imageType", DefaultOptions.IMAGE_TYPE) // Default to RGB if not provided
+    val img = imageType match {
+      case ImageType.BINARY =>
+        pdfRenderer.renderImageWithDPI(pageNumCur, resolution, PDFBoxImageType.BINARY)
+      case ImageType.GREY => pdfRenderer.renderImageWithDPI(pageNumCur, resolution, PDFBoxImageType.GRAY)
+      case _ => pdfRenderer.renderImageWithDPI(pageNumCur, resolution, PDFBoxImageType.RGB)
+    }
+    val oStream = new ByteArrayOutputStream()
+    ImageIO.write(img, outputImageType, oStream)
+    val image = oStream.toByteArray
+    oStream.close()
+    image
+  }
+
+  override def close(): Unit = {
+    if (document != null) {
+      document.close()
+    }
+    tesseract.close()
+  }
+
+  private def hasTextLayer: Boolean = {
+    stripper.setStartPage(pageNumCur + 1)
+    stripper.setEndPage(pageNumCur + 1)
+    val text = stripper.getText(document)
+    text.trim.nonEmpty
+  }
+
+  override def get(): InternalRow = {
+    val resolution = options.getOrElse("resolution", DefaultOptions.RESOLUTION).toInt
+    val forceOCR = options.getOrElse("forceOCR", "false").toBoolean
+
+    val text = if (readDataSchema.fieldNames.contains("text")) {
+      getSearchableText
+    } else ""
+
+    // Render the image from the PDF
+    val image = if (readDataSchema.fieldNames.contains("image") || readDataSchema.fieldNames.contains("document")) {
+      renderImage(resolution)
+    } else Array[Byte]()
+
+    val imageRow = InternalRow(
+      UTF8String.fromString(filename),
+      resolution,
+      image,
+      UTF8String.fromString("file"),
+      UTF8String.fromString(""),
+      0,
+      0)
+
+    // Run OCR on the image
+    val ocrDocument = if (readDataSchema.fieldNames.contains("document")) {
+      if (forceOCR || text.isEmpty || !hasTextLayer) {
+        tesseract.imageToDocument(image, PIL.WORD, 0, filename)
+      } else {
+        Document(filename, "", "", Array[Box]())
+      }
+    } else
+      Document(filename, "", "", Array[Box]())
+
+    // Assemble final row
+    InternalRow(
+      UTF8String.fromString(filename),
+      UTF8String.fromString(Paths.get(filename).getFileName.toString),
+      pageNumCur,
+      inputPartition.index,
+      UTF8String.fromString(text),
+      imageRow,
+      ocrDocument.toInternalRow
+    )
+  }
+}

--- a/src/test/scala/PdfDatasourceSuite.scala
+++ b/src/test/scala/PdfDatasourceSuite.scala
@@ -60,6 +60,16 @@ class PdfDatasourceSuite extends AnyFunSuite with BeforeAndAfterEach {
     checkOcrResulst(filePath, fileName, pdfDF)
   }
 
+  test("PDFDataSource with PdfBox and forceOCR") {
+    val (filePath, fileName, pdfDF) = readPdf(PdfReader.PDF_BOX, forceOCR = true)
+    checkOcrResulst(filePath, fileName, pdfDF)
+  }
+
+  test("PDFDataSource with PdfBox and skip OCR if text layer is present") {
+    val (filePath, fileName, pdfDF) = readPdf(PdfReader.PDF_BOX, skipOCR = true)
+    checkImegeResult(pdfDF)
+  }
+
   private def checkOcrResulst(filePath: String, fileName: String, pdfDF: DataFrame): Unit = {
     pdfDF.count() shouldBe 10
     pdfDF.columns should contain allOf("path", "page_number", "text", "image", "partition_number")
@@ -77,7 +87,7 @@ class PdfDatasourceSuite extends AnyFunSuite with BeforeAndAfterEach {
     //pdfDF.select("document.*").show(2, truncate = true)
   }
 
-  private def readPdf(reader: String, filePath: String = "pdfs/example_image_10_page.pdf") = {
+  private def readPdf(reader: String, filePath: String = "pdfs/example_image_10_page.pdf", forceOCR: Boolean = false, skipOCR: Boolean = false) = {
     val fileName = Paths.get(filePath).getFileName.toString
     val pdfPath = getClass.getClassLoader.getResource(filePath).getPath
 
@@ -88,6 +98,8 @@ class PdfDatasourceSuite extends AnyFunSuite with BeforeAndAfterEach {
       .option("pagePerPartition", "2")
       .option("reader", reader)
       .option("ocrConfig", "psm=11")
+      .option("forceOCR", forceOCR.toString)
+      .option("skipOCR", skipOCR.toString)
       .load(pdfPath)
       .cache()
     (filePath, fileName, pdfDF)
@@ -97,4 +109,3 @@ class PdfDatasourceSuite extends AnyFunSuite with BeforeAndAfterEach {
     spark.stop()
   }
 }
-


### PR DESCRIPTION
I have contributed to this repository by addressing the enhancement described in the following issue:

[Issue #4](https://github.com/StabRise/spark-pdf/issues/4)